### PR TITLE
Create stripe-keys.php

### DIFF
--- a/stripe/stripe-keys.php
+++ b/stripe/stripe-keys.php
@@ -1,0 +1,52 @@
+<?php
+require_once('vendor/autoload.php');
+
+$json = '{"publishableKey":"pk_live_51JQ6uKDPmbVVvaXBfDKJAHZQlFznTaWyRa4eTGxRtRiywz5WNAJK9QINtPjILQNjv5Tx0pvxY4ytgNSS3HaUNmoX00oaSJt0dy"}';
+$stripeKey = json_decode($json, true);
+
+\Stripe\Stripe::setApiKey("sk_test_your_secret_key");
+
+$token = $_POST['stripeToken'];
+$amount = $_POST['amount'];
+
+try {
+    $charge = \Stripe\Charge::create(array(
+        "amount" => $amount,
+        "currency" => "usd",
+        "source" => $token,
+    ));
+
+    echo 'Charge successful! Charge ID: '.$charge->id;
+
+} catch (\Stripe\Error\Card $e) {
+    echo 'Card error: ' . $e->getMessage();
+}
+?>
+
+<form action="your_server_side_script.php" method="post">
+  <script
+    src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+    data-key="<?php echo $stripeKey["publishableKey"]; ?>"
+    data-amount="999"
+    data-name="Your Product"
+    data-description="Example charge"
+    data-image="https://stripe.com/img/documentation/checkout/marketplace.png"
+    data-locale="auto">
+  </script>
+</form>
+<?php
+$json = '{"publishableKey":"pk_live_51JQ6uKDPmbVVvaXBfDKJAHZQlFznTaWyRa4eTGxRtRiywz5WNAJK9QINtPjILQNjv5Tx0pvxY4ytgNSS3HaUNmoX00oaSJt0dy"}';
+$stripeKey = json_decode($json, true);
+?>
+
+<form action="your_server_side_script.php" method="post">
+  <script
+    src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+    data-key="<?php echo $stripeKey["publishableKey"]; ?>"
+    data-amount="999"
+    data-name="Your Product"
+    data-description="Example charge"
+    data-image="https://stripe.com/img/documentation/checkout/marketplace.png"
+    data-locale="auto">
+  </script>
+</form>


### PR DESCRIPTION
The require_once statement is loading the Stripe library, but the code is not using the correct API key. The line \Stripe\Stripe::setApiKey("sk_test_your_secret_key"); should use the correct secret key for the Stripe account.
The $token and $amount variables are being set using the $_POST superglobal, but there is no indication in the code of where these values are coming from. The form in the HTML does not include any input fields for the stripeToken and amount values.
The action attribute of the form element is set to "your_server_side_script.php" but that file does not exist in the provided code.
The second form is duplicate of the first one.
The second json_decode is not needed.